### PR TITLE
avoid double saving programs

### DIFF
--- a/django_cropper_image/fields.py
+++ b/django_cropper_image/fields.py
@@ -181,7 +181,10 @@ class ImageCropperField(models.Field):
 	def pre_save(self, model_instance, add):
 		"""Return field's value just before saving."""
 		self.cropperconstobj = getattr(model_instance, self.attname)
-		self.b64data = self.cropperconstobj.get()
+		if isinstance(self.cropperconstobj, str):
+			self.b64data = ''
+		else:
+			self.b64data = self.cropperconstobj.get()
 		if self.b64data and isinstance(self.b64data, str) or self.b64data =='':
 			return self.b64data
 		cropping_image =False


### PR DESCRIPTION
If u double save, for example, in the following code, 
`user = user_form.save()` 
                `setattr(user, f'school', school)`
               `user.save()`
Then `self.cropperconstobj` would be a `str` and don't have `.get()`, so you have to avoid it. 